### PR TITLE
fix: prevent SQL injection and open redirect in go.php

### DIFF
--- a/include/go.php
+++ b/include/go.php
@@ -2,7 +2,12 @@
 
 if(!empty($_GET['url'])) {
     $url = $_GET['url'];
-    header("Location:$url");
+    // Prevent open redirect: only allow relative URLs
+    if (preg_match('/^https?:\/\//i', $url) || strpos($url, '//') === 0) {
+        header("Location: /");
+        exit();
+    }
+    header("Location:" . $url);
     exit();
 }
 include("common.php");
@@ -20,7 +25,7 @@ if($_SESSION['pass'] != 1) {
     if(!empty($pass)) {
         //用户提交登录
         $show = array();
-        $pwds = $DB->query("SELECT `pwd_id`, `pwd_key` FROM `lylme_pwd` WHERE `pwd_key` LIKE '" . $pass . "';");
+        $pwds = $DB->query("SELECT `pwd_id`, `pwd_key` FROM `lylme_pwd` WHERE `pwd_key` LIKE '" . $DB->real_escape_string($pass) . "';");
         while ($pwd = $DB->fetch($pwds)) {
             array_push($show, $pwd['pwd_id']);
         }
@@ -37,7 +42,7 @@ if($_SESSION['pass'] != 1) {
     //已登录
     if(!empty($pass)) {
         $show = array();
-        $pwds = $DB->query("SELECT `pwd_id`, `pwd_key` FROM `lylme_pwd` WHERE `pwd_key` LIKE '" . $pass . "';");
+        $pwds = $DB->query("SELECT `pwd_id`, `pwd_key` FROM `lylme_pwd` WHERE `pwd_key` LIKE '" . $DB->real_escape_string($pass) . "';");
         while ($pwd = $DB->fetch($pwds)) {
             array_push($show, $pwd['pwd_id']);
         }


### PR DESCRIPTION
## Summary

Fix SQL injection and open redirect vulnerabilities in `include/go.php`.

## Problem

### 1. Open Redirect (CWE-601)
```php
$url = $_GET['url'];
header("Location:$url");
```
User-supplied `url` parameter is passed directly to `header("Location:")` without validation, enabling phishing via redirect.

### 2. SQL Injection (CWE-89)
```php
$pwds = $DB->query("SELECT `pwd_id`, `pwd_key` FROM `lylme_pwd` WHERE `pwd_key` LIKE '" . $pass . "';");
```
The `$pass` variable (from `$_POST['pass']`) is concatenated directly into the SQL query. While `daddslashes()` is applied earlier, this does not fully prevent SQL injection in all database configurations. An attacker can inject arbitrary SQL to bypass authentication or extract data.

This pattern appears in two places (lines 23 and 33).

## Fix

1. **Open redirect**: Validate URL doesn't start with `http://`, `https://`, or `//`
2. **SQL injection**: Apply `$DB->real_escape_string()` to properly escape the password value in SQL queries

## Impact

- **Open Redirect**: Phishing via trusted domain redirect
- **SQL Injection**: Authentication bypass, data extraction
- **OWASP**: A03:2021 — Injection, A01:2021 — Broken Access Control