### PR TITLE
修复质量主题分类筛选后的错误跳转

### DIFF
--- a/template/quality6.0/list.php
+++ b/template/quality6.0/list.php
@@ -70,7 +70,7 @@
                     tools.push(item);
                     html += `
                     <div class="col-lg-3 col-md-4 col-6">
-                        <a href="site-${item.id}.html" data-id="${item.id}" class="btn btn-wider btn-block btn-xl btn-outline-light tool-link" ${item.out ? 'target="_blank"' : ''}>
+                        <a href="${item.url}" data-id="${item.id}" class="btn btn-wider btn-block btn-xl btn-outline-light tool-link" ${item.out ? 'target="_blank"' : ''}>
         ${item.icon && item.icon.trim() ? (item.icon.startsWith('<svg') ?
             `<span class="link-icon">${item.icon}</span>` :
             `<span class="link-icon"><img src="${item.icon}"></span>`) :


### PR DESCRIPTION
## 问题描述

使用 `quality6.0` 主题时，首页首次渲染的网址是正确的外部地址；点击任意分类后，`show_tool_list` 会重新生成链接，却将地址写成 `site-${item.id}.html`。

这会丢失 `listjson()` 已提供的真实网址 `item.url`。当部署环境未正确处理该内部地址时，用户会进入空白页或错误页面。

## 复现步骤

1. 启用 `quality6.0` 主题并打开首页。
2. 确认任意导航链接指向配置的外部网址。
3. 点击任意分类。
4. 再次检查同一链接，地址变为 `site-编号.html`。

## 修改内容

将分类重新渲染时的链接地址由：

```html
href="site-${item.id}.html"
```

改为：

```html
href="${item.url}"
```

该实现与首页首次渲染及 `dashlite` 主题保持一致。点击统计仍由 `/clitool` 请求处理，不受本次修改影响。

## 验证结果

- 修改仅涉及一行模板代码。
- `git diff --check` 通过。
- 在 PHP 8.2 环境执行语法检查，无语法错误。
- 实际页面回归通过：点击分类后链接仍保持为配置的外部网址，并能正常打开目标页面。