### PR TITLE
修复：分类切换泄露受保护链接

### DIFF
--- a/include/lists.php
+++ b/include/lists.php
@@ -150,7 +150,6 @@ function listjson()
         return [];
     }
 
-    $i = 0;
     $g = 0;
     $arr = [];
     $sessionList = isset($_SESSION['list']) ? $_SESSION['list'] : [];
@@ -165,7 +164,7 @@ function listjson()
         }
 
         $groupPwd = isset($group['group_pwd']) ? $group['group_pwd'] : '';
-        if (!empty($groupPwd) && !in_array($groupPwd, $sessionList, true)) {
+        if (!empty($groupPwd) && !in_array((int)$groupPwd, $sessionList, true)) {
             continue;
         }
 
@@ -177,7 +176,6 @@ function listjson()
             continue;
         }
 
-        $link_num = $DB->num_rows($group_links);
         $arr[$g] = [
             "id" => $groupId,
             "title" => isset($group['group_name']) ? $group['group_name'] : '',
@@ -188,6 +186,16 @@ function listjson()
         while ($link = $DB->fetch($group_links)) {
             if ($link === false) {
                 break;
+            }
+
+            $linkPwd = isset($link['link_pwd']) ? $link['link_pwd'] : '';
+            if (empty($groupPwd) && !empty($linkPwd) && !in_array((int)$linkPwd, $sessionList, true)) {
+                continue;
+            }
+
+            $linkStatus = isset($link['link_status']) ? $link['link_status'] : 1;
+            if (!$linkStatus) {
+                continue;
             }
 
             $linkId = isset($link['id']) ? (int) $link['id'] : 0;
@@ -205,21 +213,6 @@ function listjson()
                 "url" => $linkUrl,
                 "out" => true
             ];
-
-            $lpwd = true;
-            if ($link_num > $i) {
-                $i++;
-
-                $linkPwd = isset($link['link_pwd']) ? $link['link_pwd'] : '';
-                if (empty($groupPwd) && !empty($linkPwd) && !in_array((int)$linkPwd, $sessionList, true)) {
-                    $lpwd = false;
-                }
-
-                $linkStatus = isset($link['link_status']) ? $link['link_status'] : 1;
-                if ($linkStatus && $lpwd) {
-                    // 链接正常显示
-                }
-            }
         }
         $g++;
     }

--- a/tests/listjson_visibility_test.php
+++ b/tests/listjson_visibility_test.php
@@ -1,0 +1,120 @@
+<?php
+
+class DB
+{
+}
+
+class FakeResult
+{
+    public $rows;
+    public $position = 0;
+
+    public function __construct($rows)
+    {
+        $this->rows = array_values($rows);
+    }
+}
+
+class FakeDB extends DB
+{
+    private $groups;
+    private $linksByGroup;
+
+    public function __construct($groups, $linksByGroup)
+    {
+        $this->groups = $groups;
+        $this->linksByGroup = $linksByGroup;
+    }
+
+    public function query($sql)
+    {
+        if (strpos($sql, 'FROM `lylme_groups`') !== false) {
+            return new FakeResult($this->groups);
+        }
+
+        if (preg_match('/WHERE `group_id` = (\d+)/', $sql, $matches)) {
+            $groupId = (int)$matches[1];
+            return new FakeResult(isset($this->linksByGroup[$groupId]) ? $this->linksByGroup[$groupId] : []);
+        }
+
+        return false;
+    }
+
+    public function fetch($result)
+    {
+        if ($result->position >= count($result->rows)) {
+            return false;
+        }
+
+        return $result->rows[$result->position++];
+    }
+}
+
+require dirname(__DIR__) . '/include/lists.php';
+
+function assertSameValue($expected, $actual, $message)
+{
+    if ($expected !== $actual) {
+        fwrite(STDERR, $message . "\nExpected: " . json_encode($expected) . "\nActual: " . json_encode($actual) . "\n");
+        exit(1);
+    }
+}
+
+function groupIds($groups)
+{
+    return array_map(function ($group) {
+        return $group['id'];
+    }, $groups);
+}
+
+function itemIds($groups, $groupId)
+{
+    foreach ($groups as $group) {
+        if ($group['id'] === $groupId) {
+            return array_map(function ($item) {
+                return $item['id'];
+            }, $group['items']);
+        }
+    }
+
+    return [];
+}
+
+$groups = [
+    ['group_id' => 1, 'group_name' => 'Public', 'group_icon' => '', 'group_status' => 1, 'group_pwd' => 0],
+    ['group_id' => 2, 'group_name' => 'Protected', 'group_icon' => '', 'group_status' => 1, 'group_pwd' => '9'],
+    ['group_id' => 3, 'group_name' => 'Disabled', 'group_icon' => '', 'group_status' => 0, 'group_pwd' => 0],
+];
+
+$linksByGroup = [
+    1 => [
+        ['id' => 101, 'name' => 'Public link', 'icon' => '', 'url' => 'https://example.com/public', 'link_status' => 1, 'link_pwd' => 0],
+        ['id' => 102, 'name' => 'Protected link', 'icon' => '', 'url' => 'https://example.com/protected', 'link_status' => 1, 'link_pwd' => '7'],
+        ['id' => 103, 'name' => 'Disabled link', 'icon' => '', 'url' => 'https://example.com/disabled', 'link_status' => 0, 'link_pwd' => 0],
+    ],
+    2 => [
+        ['id' => 201, 'name' => 'Protected group link', 'icon' => '', 'url' => 'https://example.com/group', 'link_status' => 1, 'link_pwd' => '99'],
+    ],
+    3 => [
+        ['id' => 301, 'name' => 'Disabled group link', 'icon' => '', 'url' => 'https://example.com/disabled-group', 'link_status' => 1, 'link_pwd' => 0],
+    ],
+];
+
+$_SESSION['list'] = [];
+$DB = new FakeDB($groups, $linksByGroup);
+$result = listjson();
+assertSameValue([1], groupIds($result), 'Unauthenticated users must not receive protected or disabled groups.');
+assertSameValue([101], itemIds($result, 1), 'Unauthenticated users must receive only public, enabled links.');
+
+$_SESSION['list'] = [7];
+$DB = new FakeDB($groups, $linksByGroup);
+$result = listjson();
+assertSameValue([101, 102], itemIds($result, 1), 'An authorized link password must reveal only its matching links.');
+
+$_SESSION['list'] = [9];
+$DB = new FakeDB($groups, $linksByGroup);
+$result = listjson();
+assertSameValue([1, 2], groupIds($result), 'An authorized group password must reveal its matching group.');
+assertSameValue([201], itemIds($result, 2), 'An authorized group must reveal its enabled links.');
+
+echo "listjson visibility tests passed\n";


### PR DESCRIPTION
## 问题

`quality6.0` 主题首屏通过 `lists()` 正确过滤了绑定“访问管理”的分类和链接，但分类切换会使用 `listjson()` 生成的前端数据重新渲染。原实现先把链接加入 JSON，再执行访问权限与启用状态判断，因此未输入访问管理密码的用户切换分类后，会看到本应隐藏的链接。

这里的分类和链接共用现有“访问管理”功能，不是新增两套密码。

## 修改

- 在链接加入 `listjson()` 返回值之前，检查其关联的访问管理权限和启用状态。
- 移除无效的跨分类计数逻辑，逐条判断链接是否可见。
- 统一访问管理记录 ID 的整数比较方式，匹配登录会话中保存的 ID 类型。
- 增加独立回归测试，覆盖未登录、已获得访问权限、分类整体关联访问管理以及停用内容。

## 影响

分类切换和搜索使用的 JSON 数据现在与服务端首屏渲染遵循相同的可见性规则。未输入访问管理密码时，受保护内容不会再被发送到前端。

## 验证

- `php -l include/lists.php`
- `php -l tests/listjson_visibility_test.php`
- `php tests/listjson_visibility_test.php`
